### PR TITLE
Add interactive marketing spend web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,9 @@
 Welcome to the Marketing Mix Modeling (MMM) Toolkit — a comprehensive and evolving set of resources, tools, and best practices to support MMM initiatives for modern marketers and data-driven consultancies.
 
 This project is maintained by a marketing analytics consultancy aiming to deepen internal knowledge, standardize MMM workflows, and share cutting-edge insights with the broader marketing and data science community.
+
+## Web Demo
+
+Open `index.html` in a browser to explore marketing spend and sales.
+- The first chart shows past 12 months of spend by channel with revenue.
+- The second chart lets you drag future spend values (capped at €20k per month and €100k total) and view updated sales predictions based on fixed ROI per channel.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Marketing Spend and Revenue</title>
+  <link rel="stylesheet" href="style.css">
+  <!-- Explicit versions ensure drag plugin compatibility -->
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@3.9.1"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-dragdata@2.1.0"></script>
+</head>
+<body>
+  <h1>Marketing Spend & Revenue</h1>
+  <section>
+    <h2>Last 12 Months</h2>
+    <canvas id="historyChart"></canvas>
+  </section>
+  <section>
+    <h2>Next 12 Months (Drag to Adjust Spend)</h2>
+    <canvas id="planChart"></canvas>
+  </section>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,159 @@
+const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+// ----- Static history chart -----
+const historySpend = {
+  Search: [4000, 3800, 4200, 4500, 5000, 4800, 4700, 4600, 4400, 4300, 4100, 4000],
+  Social: [3000, 2800, 3000, 3200, 3300, 3400, 3500, 3600, 3500, 3400, 3300, 3200],
+  Email:  [1000, 1200, 1100, 1000, 1300, 1200, 1100, 1000, 1200, 1100, 1000, 900]
+};
+const historyRevenue = [20000, 21000, 22000, 23000, 24000, 23500, 24500, 25000, 25500, 26000, 26500, 27000];
+
+new Chart(document.getElementById('historyChart'), {
+  type: 'line',
+  data: {
+    labels: months,
+    datasets: [
+      {
+        label: 'Search',
+        data: historySpend.Search,
+        borderColor: '#4e79a7',
+        backgroundColor: 'rgba(78,121,167,0.4)',
+        fill: true,
+        stack: 'spend'
+      },
+      {
+        label: 'Social',
+        data: historySpend.Social,
+        borderColor: '#f28e2b',
+        backgroundColor: 'rgba(242,142,43,0.4)',
+        fill: true,
+        stack: 'spend'
+      },
+      {
+        label: 'Email',
+        data: historySpend.Email,
+        borderColor: '#e15759',
+        backgroundColor: 'rgba(225,87,89,0.4)',
+        fill: true,
+        stack: 'spend'
+      },
+      {
+        label: 'Revenue',
+        data: historyRevenue,
+        borderColor: '#76b7b2',
+        fill: false,
+        stack: 'revenue'
+      }
+    ]
+  },
+  options: {
+    responsive: true,
+    scales: {
+      x: { stacked: true },
+      y: { stacked: true, beginAtZero: true }
+    }
+  }
+});
+
+// ----- Interactive plan chart -----
+const totalBudget = 100000;
+const maxPerMonth = 20000;
+const baseSales = 5000;
+const roi = { Search: 4, Social: 3, Email: 2 };
+
+const planSpend = {
+  Search: Array(12).fill(3000),
+  Social: Array(12).fill(2000),
+  Email: Array(12).fill(1000)
+};
+
+function calcPredictions() {
+  return months.map((_, i) =>
+    baseSales +
+    planSpend.Search[i] * roi.Search +
+    planSpend.Social[i] * roi.Social +
+    planSpend.Email[i] * roi.Email
+  );
+}
+
+function enforceCaps(channel, month, value) {
+  let otherMonth = 0;
+  Object.keys(planSpend).forEach(key => {
+    if (key !== channel) otherMonth += planSpend[key][month];
+  });
+  let capped = Math.max(0, Math.min(value, maxPerMonth - otherMonth));
+
+  let otherTotal = 0;
+  Object.keys(planSpend).forEach(key => {
+    planSpend[key].forEach((v, idx) => {
+      if (key === channel && idx === month) return;
+      otherTotal += v;
+    });
+  });
+  const remaining = totalBudget - otherTotal;
+  return Math.min(capped, Math.max(0, remaining));
+}
+
+const planChart = new Chart(document.getElementById('planChart'), {
+  type: 'line',
+  data: {
+    labels: months,
+    datasets: [
+      {
+        label: 'Search',
+        data: planSpend.Search,
+        borderColor: '#4e79a7',
+        backgroundColor: 'rgba(78,121,167,0.4)',
+        fill: true,
+        stack: 'spend',
+        dragData: true
+      },
+      {
+        label: 'Social',
+        data: planSpend.Social,
+        borderColor: '#f28e2b',
+        backgroundColor: 'rgba(242,142,43,0.4)',
+        fill: true,
+        stack: 'spend',
+        dragData: true
+      },
+      {
+        label: 'Email',
+        data: planSpend.Email,
+        borderColor: '#e15759',
+        backgroundColor: 'rgba(225,87,89,0.4)',
+        fill: true,
+        stack: 'spend',
+        dragData: true
+      },
+      {
+        label: 'Predicted Sales',
+        data: calcPredictions(),
+        borderColor: '#59a14f',
+        fill: false,
+        stack: 'revenue'
+      }
+    ]
+  },
+  options: {
+    responsive: true,
+    plugins: {
+      dragData: {
+        round: 0,
+        onDrag: function(e, datasetIndex, index, value) {
+          const channel = e.chart.data.datasets[datasetIndex].label;
+          const newValue = enforceCaps(channel, index, value);
+          planSpend[channel][index] = newValue;
+          e.chart.data.datasets[3].data = calcPredictions();
+          e.chart.update();
+          return newValue;
+        }
+      }
+    },
+    scales: {
+      x: { stacked: true },
+      y: { stacked: true, beginAtZero: true }
+    }
+  }
+});
+

--- a/style.css
+++ b/style.css
@@ -1,0 +1,12 @@
+body {
+  font-family: sans-serif;
+  margin: 20px;
+}
+section {
+  margin-bottom: 40px;
+}
+canvas {
+  max-width: 900px;
+  width: 100%;
+  height: 400px;
+}


### PR DESCRIPTION
## Summary
- Add static stacked spend and revenue chart for last 12 months
- Add interactive planning chart for next 12 months with draggable budget and predicted sales line
- Document web demo

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f7a115030832b87568e758487a60b