### PR TITLE
Add interactive marketing dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Marketing Dashboard</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="container">
+    <h1>Marketing Performance Dashboard</h1>
+    <section>
+      <h2>Last 12 Months</h2>
+      <canvas id="historyChart"></canvas>
+    </section>
+    <section>
+      <h2>Next 12 Months</h2>
+      <div class="forecast-wrapper">
+        <canvas id="forecastChart"></canvas>
+        <div id="allocationInfo">Allocated: €0</div>
+      </div>
+    </section>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-dragdata@2.1.0"></script>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,144 @@
+// Utility functions to generate month labels
+function getPastMonths(n) {
+  const labels = [];
+  const date = new Date();
+  for (let i = n - 1; i >= 0; i--) {
+    const d = new Date(date.getFullYear(), date.getMonth() - i, 1);
+    labels.push(d.toLocaleString('default', { month: 'short' }));
+  }
+  return labels;
+}
+
+function getFutureMonths(n) {
+  const labels = [];
+  const date = new Date();
+  for (let i = 1; i <= n; i++) {
+    const d = new Date(date.getFullYear(), date.getMonth() + i, 1);
+    labels.push(d.toLocaleString('default', { month: 'short' }));
+  }
+  return labels;
+}
+
+// ----- Static chart for past 12 months -----
+const pastLabels = getPastMonths(12);
+const pastSocial = [4000,5000,4500,6000,7000,5000,6500,7000,6000,5500,6000,6500];
+const pastSearch = [3000,3500,3200,4000,4500,3800,4200,4600,4300,4100,4400,4800];
+const pastDisplay = [2000,2500,2200,3000,2800,2600,2700,2900,2500,2400,2600,3000];
+const pastRevenue = pastSocial.map((_,i)=>{
+  return (pastSocial[i]+pastSearch[i]+pastDisplay[i]) * 1.8;
+});
+
+const historyCtx = document.getElementById('historyChart').getContext('2d');
+const historyChart = new Chart(historyCtx, {
+  type: 'line',
+  data: {
+    labels: pastLabels,
+    datasets: [
+      {label:'Social', data: pastSocial, backgroundColor:'rgba(54,162,235,0.5)', borderColor:'rgba(54,162,235,1)', fill:true, stack:'spend'},
+      {label:'Search', data: pastSearch, backgroundColor:'rgba(255,99,132,0.5)', borderColor:'rgba(255,99,132,1)', fill:true, stack:'spend'},
+      {label:'Display', data: pastDisplay, backgroundColor:'rgba(75,192,192,0.5)', borderColor:'rgba(75,192,192,1)', fill:true, stack:'spend'},
+      {label:'Revenue', data: pastRevenue, borderColor:'#000', fill:false, borderWidth:2, yAxisID:'y1'}
+    ]
+  },
+  options: {
+    responsive:true,
+    interaction:{mode:'index', intersect:false},
+    stacked:false,
+    plugins:{legend:{position:'top'}},
+    scales:{
+      y:{stacked:true, title:{display:true, text:'€'}},
+      y1:{position:'right', title:{display:true, text:'€'}, grid:{drawOnChartArea:false}}
+    }
+  }
+});
+
+// ----- Interactive chart for next 12 months -----
+const futureLabels = getFutureMonths(12);
+const futureSocial = Array(12).fill(2000);
+const futureSearch = Array(12).fill(1500);
+const futureDisplay = Array(12).fill(1000);
+
+const forecastCtx = document.getElementById('forecastChart').getContext('2d');
+
+const forecastChart = new Chart(forecastCtx, {
+  type: 'line',
+  data: {
+    labels: futureLabels,
+    datasets: [
+      {label:'Social', data: futureSocial, backgroundColor:'rgba(54,162,235,0.5)', borderColor:'rgba(54,162,235,1)', fill:true, stack:'spend', dragData:true},
+      {label:'Search', data: futureSearch, backgroundColor:'rgba(255,99,132,0.5)', borderColor:'rgba(255,99,132,1)', fill:true, stack:'spend', dragData:true},
+      {label:'Display', data: futureDisplay, backgroundColor:'rgba(75,192,192,0.5)', borderColor:'rgba(75,192,192,1)', fill:true, stack:'spend', dragData:true},
+      {label:'Predicted Sales', data:Array(12).fill(0), borderColor:'#000', fill:false, borderWidth:2, dragData:false}
+    ]
+  },
+  options: {
+    responsive:true,
+    interaction:{mode:'index', intersect:false},
+    plugins:{
+      legend:{position:'top'},
+      dragData:{
+        round:0,
+        showTooltip:true,
+        onDrag:function(e, datasetIndex, index, value){
+          const capped = clampValue(datasetIndex, index, value);
+          forecastChart.data.datasets[datasetIndex].data[index] = capped;
+          updatePredicted();
+          updateAllocationInfo();
+          return capped;
+        }
+      }
+    },
+    scales:{
+      y:{stacked:true, title:{display:true, text:'€'}},
+    }
+  }
+});
+
+function clampValue(datasetIndex, index, newValue){
+  // monthly cap 20k
+  let otherMonthly = 0;
+  forecastChart.data.datasets.forEach((ds,i)=>{
+    if(ds.stack==='spend' && i!==datasetIndex){
+      otherMonthly += ds.data[index];
+    }
+  });
+  let capped = Math.min(newValue, 20000 - otherMonthly);
+  if(capped < 0) capped = 0;
+
+  // total cap 100k
+  let sumExcept = 0;
+  forecastChart.data.datasets.forEach((ds,i)=>{
+    if(ds.stack==='spend'){
+      ds.data.forEach((v,idx)=>{
+        if(!(i===datasetIndex && idx===index)) sumExcept += v;
+      });
+    }
+  });
+  const remaining = 100000 - sumExcept;
+  capped = Math.min(capped, remaining);
+  if(capped < 0) capped = 0;
+  return capped;
+}
+
+function updatePredicted(){
+  const predicted = forecastChart.data.datasets.find(ds=>ds.label==='Predicted Sales');
+  for(let i=0;i<futureLabels.length;i++){
+    let monthly = 0;
+    forecastChart.data.datasets.forEach(ds=>{
+      if(ds.stack==='spend') monthly += ds.data[i];
+    });
+    predicted.data[i] = monthly * 1.5; // simple ROI assumption
+  }
+  forecastChart.update();
+}
+
+function updateAllocationInfo(){
+  let total = 0;
+  forecastChart.data.datasets.forEach(ds=>{
+    if(ds.stack==='spend') total += ds.data.reduce((a,b)=>a+b,0);
+  });
+  document.getElementById('allocationInfo').innerText = `Allocated: €${total.toFixed(0)}`;
+}
+
+updatePredicted();
+updateAllocationInfo();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,43 @@
+body {
+  font-family: Arial, sans-serif;
+  background: #f4f4f9;
+  margin: 0;
+  padding: 0;
+  color: #333;
+}
+
+.container {
+  width: 90%;
+  max-width: 1000px;
+  margin: 20px auto;
+}
+
+h1 {
+  text-align: center;
+  color: #444;
+}
+
+section {
+  margin-bottom: 40px;
+}
+
+canvas {
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+}
+
+.forecast-wrapper {
+  position: relative;
+}
+
+#allocationInfo {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: rgba(255,255,255,0.9);
+  padding: 8px 12px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- Build static chart visualizing past spend across channels with revenue line.
- Introduce interactive forecast chart with drag-to-adjust spending and auto-updated sales projection.
- Display live allocation total and enforce monthly and overall spend caps.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f8dd02ae4832ba8ed77d69add479b